### PR TITLE
Add a manual page

### DIFF
--- a/man/pycowsay.6
+++ b/man/pycowsay.6
@@ -1,0 +1,41 @@
+.TH PYCOWSAY 6 "12 October 2023" "0.0.0.1"
+.SH NAME
+pycowsay \- speaking cow
+.SH SYNOPSIS
+.SY pycowsay
+.RI [ message \&.\|.\|.]\&
+.YS
+.SY pycowsay
+.B \-\-help
+.YS
+.SY pycowsay
+.B \-\-version
+.YS
+.SH DESCRIPTION
+.B pycowsay
+generates an ASCII picture of a cow saying something provided by the user. The
+command-line arguments
+.I message
+are the cow's message.
+.SH OPTIONS
+.TP
+.BR \-\-help
+Print a help message and exit.
+.TP
+.BR \-\-version
+Display version information.
+.SH EXIT STATUS
+.B pycowsay
+exists with status 0.
+.SH REPORTING BUGS
+Report bugs on
+.UR https://\:github.com/\:cs01/\:pycowsay/\:issues
+GitHub
+.UE .
+.SH COPYRIGHT
+Copyright (c) 2019-2023 Chad Smith. This program is distributed under an MIT
+license. See the file
+.I LICENSE
+distributed with this program for details.
+.SH SEE ALSO
+.BR cowsay (6)

--- a/man/pycowsay.6
+++ b/man/pycowsay.6
@@ -1,6 +1,6 @@
 .TH PYCOWSAY 6 "12 October 2023" "0.0.0.1"
 .SH NAME
-pycowsay \- speaking cow
+pycowsay \- a talking cow
 .SH SYNOPSIS
 .SY pycowsay
 .RI [ message \&.\|.\|.]\&

--- a/man/pycowsay.6
+++ b/man/pycowsay.6
@@ -33,7 +33,7 @@ Report bugs on
 GitHub
 .UE .
 .SH COPYRIGHT
-Copyright (c) 2019-2023 Chad Smith. This program is distributed under an MIT
+Copyright (c) 2019-2023 Chad Smith. This program is distributed under the MIT
 license. See the file
 .I LICENSE
 distributed with this program for details.

--- a/man/pycowsay.6
+++ b/man/pycowsay.6
@@ -26,7 +26,7 @@ Print a help message and exit.
 Display version information.
 .SH EXIT STATUS
 .B pycowsay
-exists with status 0.
+always exits with status 0.
 .SH REPORTING BUGS
 Report bugs on
 .UR https://\:github.com/\:cs01/\:pycowsay/\:issues

--- a/man/pycowsay.6
+++ b/man/pycowsay.6
@@ -3,13 +3,9 @@
 pycowsay \- a talking cow
 .SH SYNOPSIS
 .SY pycowsay
+.OP \-\-help
+.OP \-\-version
 .RI [ message \&.\|.\|.]\&
-.YS
-.SY pycowsay
-.B \-\-help
-.YS
-.SY pycowsay
-.B \-\-version
 .YS
 .SH DESCRIPTION
 .B pycowsay

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     keywords=[],
     scripts=[],
     entry_points={"console_scripts": ["pycowsay=pycowsay.main:main"]},
+    data_files=[("share/man/man6", ["man/pycowsay.6"])],
     zip_safe=False,
     install_requires=DEPENDENCIES,
     test_suite="tests.test_project",


### PR DESCRIPTION
Here is a proposed manual page. It is installed under `share/man/man6` with the `data_files` directive in `setup.py`.

Notes:

- I used the manual page section 6 (Games) because that is where the manual page of cowsay is located.
- The version number (currently 0.0.0.1) is included in the manual page, which needs to be changed on version changes.
- Reporting bugs section points to Issues on GitHub in [cs01/pycowsay](https://github.com/cs01/pycowsay/).
- The synopsis differs slightly from the command line help message (`pycowsay [message...]` in the manual page vs. `cowsay MESSAGE [MESSAGE]` in the help message). As it is currently implemented, all of the command line arguments are optional. The help message in the code should probably be changed to `pycowsay [MESSAGE...]`.